### PR TITLE
Fix typo in comment: "ibject" -> "object"

### DIFF
--- a/src/webauthn.js
+++ b/src/webauthn.js
@@ -47,7 +47,7 @@ const createCreds = async function() {
     }
     ////// END server generated info //////
     
-    // browser receives the publicKey ibject and passes it to WebAuthn "create" API
+    // browser receives the publicKey object and passes it to WebAuthn "create" API
     const res = await navigator.credentials.create({
             publicKey: publicKey
         })
@@ -83,7 +83,7 @@ const validateCreds = async function(){
     };
     ////// END server generated info //////
 
-    // browser receives the publicKey ibject and passes it to WebAuthn "get" API
+    // browser receives the publicKey object and passes it to WebAuthn "get" API
     const res = await navigator.credentials.get({
         publicKey: publicKey
       })


### PR DESCRIPTION
Fix typo in comment: `"ibject"` -> `"object"`.